### PR TITLE
Don't send player anywhere after beating a gym

### DIFF
--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -123,8 +123,7 @@ class GymRunner {
 
             // Award money for defeating gym
             App.game.wallet.gainMoney(gym.moneyReward);
-            // Send the player back to the town they were in
-            player.town(gym.parent);
+            // Send the player back to a town state
             App.game.gameState = GameConstants.GameState.town;
         }
     }


### PR DESCRIPTION
## Description
Removed the line that sends the player back to the parent town of a gym after beating it.
`gymLost()` doesn't use this line, and winning a gym without this sends the player back to the town the gym was initiated in.

## Motivation and Context
I'd like for some gyms to be battled in multiple locations for my Alola rework. This includes the motivations of:
- We can use gyms more liberally (for quests or otherwise) without sending the player to a locked location afterwards
- Players can enjoy some variety in terms of backgrounds by choosing where to fight certain gyms


## How Has This Been Tested?
1) Commented out the code
2) Checked if it broke in the following circumstances:
   - Winning a gym for the first time
   - Winning in a town with multiple gyms
   - Winning in a gym in multiple towns