### PR TITLE
Change default ItemHandler evo stone observables from Fire Stone to Leaf Stone

### DIFF
--- a/src/modules/items/ItemHandler.ts
+++ b/src/modules/items/ItemHandler.ts
@@ -6,8 +6,8 @@ import { PokemonNameType } from '../pokemons/PokemonNameType';
 import { StoneType } from '../GameConstants';
 
 export default class ItemHandler {
-    public static stoneSelected: Observable<string> = ko.observable('Fire_stone');
-    public static pokemonSelected: Observable<PokemonNameType> = ko.observable('Vulpix');
+    public static stoneSelected: Observable<string> = ko.observable('Leaf_stone');
+    public static pokemonSelected: Observable<PokemonNameType> = ko.observable('Gloom');
     public static amountSelected: Observable<number> = ko.observable(1);
     static amount: Observable<number> = ko.observable(1);
     // public static amountToUse = 1;


### PR DESCRIPTION
Fire stone -> Leaf stone
Vulpix -> Gloom

## Description
Changes default stone and mon selection in evolution stones to be the first ones in the current selection.

## Motivation and Context
- ItemHandler wasn't updated after changing the item order in #1690
- Was bothering me

## How Has This Been Tested?
It hasn't

## Types of changes
- Ones no one cares about otherwise this would have already been fixed within the past 2 years
